### PR TITLE
Feature strftime milliseconds

### DIFF
--- a/libavformat/segment.c
+++ b/libavformat/segment.c
@@ -42,6 +42,7 @@
 #include "libavutil/timecode.h"
 #include "libavutil/time_internal.h"
 #include "libavutil/timestamp.h"
+#include "libavutil/strftime_ms.h"
 
 typedef struct SegmentListEntry {
     int index;
@@ -196,11 +197,9 @@ static int set_segment_filename(AVFormatContext *s)
     if (seg->segment_idx_wrap)
         seg->segment_idx %= seg->segment_idx_wrap;
     if (seg->use_strftime) {
-        time_t now0;
-        struct tm *tm, tmpbuf;
-        time(&now0);
-        tm = localtime_r(&now0, &tmpbuf);
-        if (!strftime(oc->filename, sizeof(oc->filename), s->filename, tm)) {
+        struct timeval tv;
+        gettimeofday(&tv, NULL);
+	if (!strftime_ms(oc->filename, sizeof(oc->filename), s->filename, &tv)) {
             av_log(oc, AV_LOG_ERROR, "Could not get segment filename with strftime\n");
             return AVERROR(EINVAL);
         }

--- a/libavformat/segment.c
+++ b/libavformat/segment.c
@@ -199,7 +199,7 @@ static int set_segment_filename(AVFormatContext *s)
     if (seg->use_strftime) {
         struct timeval tv;
         gettimeofday(&tv, NULL);
-    if (!strftime_ms(oc->filename, sizeof(oc->filename), s->filename, &tv)) {
+        if (!strftime_ms(oc->filename, sizeof(oc->filename), s->filename, &tv)) {
             av_log(oc, AV_LOG_ERROR, "Could not get segment filename with strftime\n");
             return AVERROR(EINVAL);
         }

--- a/libavformat/segment.c
+++ b/libavformat/segment.c
@@ -199,7 +199,7 @@ static int set_segment_filename(AVFormatContext *s)
     if (seg->use_strftime) {
         struct timeval tv;
         gettimeofday(&tv, NULL);
-	if (!strftime_ms(oc->filename, sizeof(oc->filename), s->filename, &tv)) {
+    if (!strftime_ms(oc->filename, sizeof(oc->filename), s->filename, &tv)) {
             av_log(oc, AV_LOG_ERROR, "Could not get segment filename with strftime\n");
             return AVERROR(EINVAL);
         }

--- a/libavutil/Makefile
+++ b/libavutil/Makefile
@@ -76,6 +76,7 @@ HEADERS = adler32.h                                                     \
           version.h                                                     \
           xtea.h                                                        \
           tea.h                                                         \
+          strftime_ms.h                                                 \
 
 HEADERS-$(CONFIG_LZO)                   += lzo.h
 
@@ -153,6 +154,7 @@ OBJS = adler32.o                                                        \
        xga_font_data.o                                                  \
        xtea.o                                                           \
        tea.o                                                            \
+       strftime_ms.o                                                    \
 
 OBJS-$(!HAVE_ATOMICS_NATIVE)            += atomic.o                     \
 

--- a/libavutil/strftime_ms.c
+++ b/libavutil/strftime_ms.c
@@ -6,10 +6,10 @@
 
 #include "strftime_ms.h"
 
-size_t		strftime_ms(char* ptr,
-			    size_t max,
-			    const char* format,
-			    const struct timeval* tv)
+size_t      strftime_ms(char* ptr,
+                        size_t max,
+                        const char* format,
+                        const struct timeval* tv)
 {
     const char	*seek_format;
     char	*seek_strftime_format;
@@ -21,49 +21,50 @@ size_t		strftime_ms(char* ptr,
     strftime_format_size = strlen(format);
     seek_format = format;
     while ((seek_format = strstr(seek_format, "%")) != NULL)
-      {
-	switch (seek_format[1])
-	  {
-	  case 'L':
-	    strftime_format_size += 1;
-	    break;
-	  }
-	seek_format += 2;
-      }
+    {
+        switch (seek_format[1])
+        {
+        case 'L':
+            strftime_format_size += 1;
+            break;
+        }
+        seek_format += 2;
+    }
     strftime_format = malloc(strftime_format_size + 1);
     if (strftime_format == NULL)
-      return 0;
+        return 0;
     seek_format = format;
     seek_strftime_format = strftime_format;
     while ((seek_format = strstr(format, "%")) != NULL)
-      {
-	memcpy(seek_strftime_format, format, seek_format - format);
-	seek_strftime_format += seek_format - format;
-	format = seek_format;
-	switch (seek_format[1])
-	  {
-	  case 'L':
-	    sprintf(seek_strftime_format, "%03ld", tv->tv_usec/1000);
-	    seek_strftime_format += 3;
-	    seek_format += 2;
-	    format = seek_format;
-	    break;
-	  default:
-	    memcpy(seek_strftime_format, format, 2);
-	    seek_format += 2;
-	    seek_strftime_format += seek_format - format;
-	    format = seek_format;
-	  }
-      }
+    {
+        memcpy(seek_strftime_format, format, seek_format - format);
+        seek_strftime_format += seek_format - format;
+        format = seek_format;
+        switch (seek_format[1])
+        {
+        case 'L':
+            sprintf(seek_strftime_format, "%03ld", tv->tv_usec/1000);
+            seek_strftime_format += 3;
+            seek_format += 2;
+            format = seek_format;
+            break;
+        default:
+            memcpy(seek_strftime_format, format, 2);
+            seek_format += 2;
+            seek_strftime_format += seek_format - format;
+            format = seek_format;
+        }
+    }
     memcpy(seek_strftime_format, format, strlen(format));
     seek_strftime_format[strlen(format)] = '\0';
     tm = localtime(&(tv->tv_sec));
     if(tm == NULL)
-      {
-	free(strftime_format);
-	return 0;
-      }
+    {
+        free(strftime_format);
+        return 0;
+    }
     result = strftime(ptr, max, strftime_format, tm);
     free(strftime_format);
     return result;
 }
+

--- a/libavutil/strftime_ms.c
+++ b/libavutil/strftime_ms.c
@@ -1,0 +1,69 @@
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include "strftime_ms.h"
+
+size_t		strftime_ms(char* ptr,
+			    size_t max,
+			    const char* format,
+			    const struct timeval* tv)
+{
+    const char	*seek_format;
+    char	*seek_strftime_format;
+    size_t	strftime_format_size;
+    char	*strftime_format;
+    struct tm	*tm;
+    size_t	result;
+
+    strftime_format_size = strlen(format);
+    seek_format = format;
+    while ((seek_format = strstr(seek_format, "%")) != NULL)
+      {
+	switch (seek_format[1])
+	  {
+	  case 'L':
+	    strftime_format_size += 1;
+	    break;
+	  }
+	seek_format += 2;
+      }
+    strftime_format = malloc(strftime_format_size + 1);
+    if (strftime_format == NULL)
+      return 0;
+    seek_format = format;
+    seek_strftime_format = strftime_format;
+    while ((seek_format = strstr(format, "%")) != NULL)
+      {
+	memcpy(seek_strftime_format, format, seek_format - format);
+	seek_strftime_format += seek_format - format;
+	format = seek_format;
+	switch (seek_format[1])
+	  {
+	  case 'L':
+	    sprintf(seek_strftime_format, "%03ld", tv->tv_usec/1000);
+	    seek_strftime_format += 3;
+	    seek_format += 2;
+	    format = seek_format;
+	    break;
+	  default:
+	    memcpy(seek_strftime_format, format, 2);
+	    seek_format += 2;
+	    seek_strftime_format += seek_format - format;
+	    format = seek_format;
+	  }
+      }
+    memcpy(seek_strftime_format, format, strlen(format));
+    seek_strftime_format[strlen(format)] = '\0';
+    tm = localtime(&(tv->tv_sec));
+    if(tm == NULL)
+      {
+	free(strftime_format);
+	return 0;
+      }
+    result = strftime(ptr, max, strftime_format, tm);
+    free(strftime_format);
+    return result;
+}

--- a/libavutil/strftime_ms.c
+++ b/libavutil/strftime_ms.c
@@ -11,12 +11,12 @@ size_t      strftime_ms(char* ptr,
                         const char* format,
                         const struct timeval* tv)
 {
-    const char	*seek_format;
-    char	*seek_strftime_format;
-    size_t	strftime_format_size;
-    char	*strftime_format;
-    struct tm	*tm;
-    size_t	result;
+    const char  *seek_format;
+    char        *seek_strftime_format;
+    size_t      strftime_format_size;
+    char        *strftime_format;
+    struct tm   *tm;
+    size_t      result;
 
     strftime_format_size = strlen(format);
     seek_format = format;
@@ -24,9 +24,14 @@ size_t      strftime_ms(char* ptr,
         switch (seek_format[1]) {
         case 'L':
             strftime_format_size += 1;
+            seek_format += 2;
             break;
+        case '\0':
+            seek_format += 1;
+            break;
+        default:
+            seek_format += 2;
         }
-        seek_format += 2;
     }
     strftime_format = malloc(strftime_format_size + 1);
     if (strftime_format == NULL)
@@ -39,9 +44,18 @@ size_t      strftime_ms(char* ptr,
         format = seek_format;
         switch (seek_format[1]) {
         case 'L':
-            sprintf(seek_strftime_format, "%03ld", tv->tv_usec/1000);
+            if (!snprintf(seek_strftime_format,
+                          strftime_format_size,
+                          "%03ld", tv->tv_usec/1000)) {
+                free(strftime_format);
+                return 0;
+            }
             seek_strftime_format += 3;
             seek_format += 2;
+            format = seek_format;
+            break;
+        case '\0':
+            seek_format += 1;
             format = seek_format;
             break;
         default:

--- a/libavutil/strftime_ms.c
+++ b/libavutil/strftime_ms.c
@@ -65,8 +65,7 @@ size_t      strftime_ms(char* ptr,
             format = seek_format;
         }
     }
-    memcpy(seek_strftime_format, format, strlen(format));
-    seek_strftime_format[strlen(format)] = '\0';
+    strcpy(seek_strftime_format, format);
     tm = localtime(&(tv->tv_sec));
     if(tm == NULL) {
         free(strftime_format);

--- a/libavutil/strftime_ms.c
+++ b/libavutil/strftime_ms.c
@@ -20,10 +20,8 @@ size_t      strftime_ms(char* ptr,
 
     strftime_format_size = strlen(format);
     seek_format = format;
-    while ((seek_format = strstr(seek_format, "%")) != NULL)
-    {
-        switch (seek_format[1])
-        {
+    while ((seek_format = strstr(seek_format, "%")) != NULL) {
+        switch (seek_format[1]) {
         case 'L':
             strftime_format_size += 1;
             break;
@@ -35,13 +33,11 @@ size_t      strftime_ms(char* ptr,
         return 0;
     seek_format = format;
     seek_strftime_format = strftime_format;
-    while ((seek_format = strstr(format, "%")) != NULL)
-    {
+    while ((seek_format = strstr(format, "%")) != NULL) {
         memcpy(seek_strftime_format, format, seek_format - format);
         seek_strftime_format += seek_format - format;
         format = seek_format;
-        switch (seek_format[1])
-        {
+        switch (seek_format[1]) {
         case 'L':
             sprintf(seek_strftime_format, "%03ld", tv->tv_usec/1000);
             seek_strftime_format += 3;
@@ -58,8 +54,7 @@ size_t      strftime_ms(char* ptr,
     memcpy(seek_strftime_format, format, strlen(format));
     seek_strftime_format[strlen(format)] = '\0';
     tm = localtime(&(tv->tv_sec));
-    if(tm == NULL)
-    {
+    if(tm == NULL) {
         free(strftime_format);
         return 0;
     }

--- a/libavutil/strftime_ms.h
+++ b/libavutil/strftime_ms.h
@@ -4,9 +4,9 @@
 # include <time.h>
 # include <sys/time.h>
 
-size_t	strftime_ms(char* ptr,
-		    size_t maxsize,
-		    const char* format,
-		    const struct timeval* tv);
+size_t      strftime_ms(char* ptr,
+                        size_t maxsize,
+                        const char* format,
+                        const struct timeval* tv);
 
 #endif /* !STRFTIME_MS_H_ */

--- a/libavutil/strftime_ms.h
+++ b/libavutil/strftime_ms.h
@@ -1,0 +1,12 @@
+#ifndef STRFTIME_MS_H_
+# define STRFTIME_MS_H_
+
+# include <time.h>
+# include <sys/time.h>
+
+size_t	strftime_ms(char* ptr,
+		    size_t maxsize,
+		    const char* format,
+		    const struct timeval* tv);
+
+#endif /* !STRFTIME_MS_H_ */


### PR DESCRIPTION
'strftime_ms' function has been added to 'libavutil' (libavutil/strftime_ms.{c,h}) so 'strftime' option of format 'segment' (libavformat/segment.c) can use %L in its strftime function template to have milliseconds.